### PR TITLE
Adding an example for Aggregate and Send metrics

### DIFF
--- a/examples/pytorch/mnist-autolog-example3.py
+++ b/examples/pytorch/mnist-autolog-example3.py
@@ -1,0 +1,246 @@
+#
+# Trains an MNIST digit recognizer using PyTorch Lightning,
+# and uses Mlflow to log metrics, params and artifacts
+# NOTE: This example requires you to first install
+# pytorch-lightning (using pip install pytorch-lightning)
+#       and mlflow (using pip install mlflow).
+#
+import pytorch_lightning as pl
+import torch
+from argparse import ArgumentParser
+from mlflow.pytorch.pytorch_autolog import __MLflowPLCallback
+from pytorch_lightning.logging import MLFlowLogger
+from sklearn.metrics import accuracy_score
+from torch.nn import functional as F
+from torch.utils.data import DataLoader, random_split
+from torchvision import datasets, transforms
+
+
+class LightningMNISTClassifier(pl.LightningModule):
+    def __init__(self, **kwargs):
+        """
+        Initializes the network
+        """
+        super(LightningMNISTClassifier, self).__init__()
+
+        # mnist images are (1, 28, 28) (channels, width, height)
+        self.layer_1 = torch.nn.Linear(28 * 28, 128)
+        self.layer_2 = torch.nn.Linear(128, 256)
+        self.layer_3 = torch.nn.Linear(256, 10)
+        self.args = kwargs
+
+        # transforms for images
+        self.transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+        )
+
+    @staticmethod
+    def add_model_specific_args(parent_parser):
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=64,
+            metavar="N",
+            help="input batch size for training (default: 64)",
+        )
+        parser.add_argument(
+            "--num-workers",
+            type=int,
+            default=0,
+            metavar="N",
+            help="number of workers (default: 0)",
+        )
+        parser.add_argument(
+            "--lr",
+            type=float,
+            default=1e-3,
+            metavar="LR",
+            help="learning rate (default: 1e-3)",
+        )
+        return parser
+
+    def forward(self, x):
+        """
+        Forward Function
+        """
+        batch_size, channels, width, height = x.size()
+
+        # (b, 1, 28, 28) -> (b, 1*28*28)
+        x = x.view(batch_size, -1)
+
+        # layer 1 (b, 1*28*28) -> (b, 128)
+        x = self.layer_1(x)
+        x = torch.relu(x)
+
+        # layer 2 (b, 128) -> (b, 256)
+        x = self.layer_2(x)
+        x = torch.relu(x)
+
+        # layer 3 (b, 256) -> (b, 10)
+        x = self.layer_3(x)
+
+        # probability distribution over labels
+        x = torch.log_softmax(x, dim=1)
+
+        return x
+
+    def cross_entropy_loss(self, logits, labels):
+        """
+        Loss Fn to compute loss
+        """
+        return F.nll_loss(logits, labels)
+
+    def training_step(self, train_batch, batch_idx):
+        """
+        training the data as batches and returns training loss on each batch
+        """
+        x, y = train_batch
+        logits = self.forward(x)
+        loss = self.cross_entropy_loss(logits, y)
+        return {"loss": loss}
+
+    def validation_step(self, val_batch, batch_idx):
+        """
+        Performs validation of data in batches
+        """
+        x, y = val_batch
+        logits = self.forward(x)
+        loss = self.cross_entropy_loss(logits, y)
+        return {"val_loss": loss}
+
+    def validation_epoch_end(self, outputs):
+        """
+        Computes average validation accuracy
+        """
+        avg_loss = torch.stack([x["val_loss"] for x in outputs]).mean()
+        tensorboard_logs = {"val_loss": avg_loss}
+        return {"avg_val_loss": avg_loss, "log": tensorboard_logs}
+
+    def test_step(self, test_batch, batch_idx):
+        """
+        Performs test and computes test accuracy
+        """
+        x, y = test_batch
+        output = self.forward(x)
+        a, y_hat = torch.max(output, dim=1)
+        test_acc = accuracy_score(y_hat.cpu(), y.cpu())
+        return {"test_acc": torch.tensor(test_acc)}
+
+    def test_epoch_end(self, outputs):
+        """
+        Computes average test accuracy score
+        """
+        avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
+        return {"avg_test_acc": avg_test_acc}
+
+    def prepare_data(self):
+        """
+        Preprocess the input data.
+        """
+        return {}
+
+    def train_dataloader(self):
+        """
+        Loading training data as batches
+        """
+        mnist_train = datasets.MNIST(
+            "dataset", download=True, train=True, transform=self.transform
+        )
+        return DataLoader(
+            mnist_train,
+            batch_size=self.args["batch_size"],
+            num_workers=self.args["num_workers"],
+        )
+
+    def val_dataloader(self):
+        """
+        Loading validation data as batches
+        """
+        mnist_train = datasets.MNIST(
+            "dataset", download=True, train=True, transform=self.transform
+        )
+        mnist_train, mnist_val = random_split(mnist_train, [55000, 5000])
+
+        return DataLoader(
+            mnist_val,
+            batch_size=self.args["batch_size"],
+            num_workers=self.args["num_workers"],
+        )
+
+    def test_dataloader(self):
+        """
+        Loading test data as batches
+        """
+        mnist_test = datasets.MNIST(
+            "dataset", download=True, train=False, transform=self.transform
+        )
+        return DataLoader(
+            mnist_test,
+            batch_size=self.args["batch_size"],
+            num_workers=self.args["num_workers"],
+        )
+
+    def configure_optimizers(self):
+        """
+        Creates and returns Optimizer
+        """
+        self.optimizer = torch.optim.Adam(self.parameters(), lr=self.args["lr"])
+        self.scheduler = {
+            "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
+                self.optimizer,
+                mode="min",
+                factor=0.2,
+                patience=2,
+                min_lr=1e-6,
+                verbose=True,
+            )
+        }
+        return [self.optimizer], [self.scheduler]
+
+    def optimizer_step(
+        self,
+        epoch,
+        batch_idx,
+        optimizer,
+        optimizer_idx,
+        second_order_closure=None,
+        on_tpu=False,
+        using_lbfgs=False,
+        using_native_amp=False,
+    ):
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="PyTorch Lightning Mnist Example")
+
+    # Add trainer specific arguments
+    parser.add_argument(
+        "--max_epochs", type=int, default=5, help="number of epochs to run (default: 5)"
+    )
+    parser.add_argument(
+        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
+    )
+    parser.add_argument(
+        "--distributed_backend",
+        type=str,
+        default=None,
+        help="Distributed Backend - (default: None)",
+    )
+    parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
+
+    args = parser.parse_args()
+    dict_args = vars(args)
+    model = LightningMNISTClassifier(**dict_args)
+    mlflow_logger = MLFlowLogger(
+        experiment_name="EXPERIMENT_NAME", tracking_uri="http://IP:PORT/"
+    )
+    trainer = pl.Trainer.from_argparse_args(
+        args,
+        logger=mlflow_logger,
+        callbacks=[__MLflowPLCallback(aggregation_step=500)]
+    )
+    trainer.fit(model)
+    trainer.test()

--- a/mlflow/pytorch/pytorch_autolog.py
+++ b/mlflow/pytorch/pytorch_autolog.py
@@ -21,10 +21,10 @@ class __MLflowPLCallback(pl.Callback):
     Callback for auto-logging metrics and parameters.
     """
 
-    def __init__(self, log_every_n_iter=1):
+    def __init__(self, log_every_n_iter=1, aggregation_step=None):
         super().__init__()
-        if log_every_n_iter:
-            self.every_n_iter = log_every_n_iter
+        self.every_n_iter = log_every_n_iter
+        self.aggregation_step = aggregation_step
 
     def on_epoch_end(self, trainer, pl_module):
         """
@@ -33,13 +33,17 @@ class __MLflowPLCallback(pl.Callback):
         if (pl_module.current_epoch - 1) % self.every_n_iter == 0:
             metrics = trainer.callback_metrics
 
-            for key, value in metrics.items():
-                trainer.logger.experiment.log_metric(
-                    trainer.logger.run_id,
-                    key,
-                    float(value),
-                    step=pl_module.current_epoch,
-                )
+            if self.aggregation_step:
+                metrics = dict((key, float(value)) for key, value in metrics.items())
+                trainer.logger.agg_and_log_metrics(metrics=metrics, step=self.aggregation_step)
+            else:
+                for key, value in metrics.items():
+                    trainer.logger.experiment.log_metric(
+                        trainer.logger.run_id,
+                        key,
+                        float(value),
+                        step=pl_module.current_epoch,
+                    )
         if trainer.early_stop_callback:
             self._early_stop_check(trainer=trainer)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding an example for aggregating and sending the metrics using pytorch lightning inbuilt utility

## How is this patch tested?

Some tests similar to the Keras, fastai ones have been written to ensure model exporting and autologging works in most cases.


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
