### PR TITLE
Changing key name to val_loss and ignoring the duplicate metrics in t…

### DIFF
--- a/examples/pytorch/mnist-autolog-example1.py
+++ b/examples/pytorch/mnist-autolog-example1.py
@@ -111,15 +111,14 @@ class LightningMNISTClassifier(pl.LightningModule):
         x, y = val_batch
         logits = self.forward(x)
         loss = self.cross_entropy_loss(logits, y)
-        return {"val_loss": loss}
+        return {"val_step_loss": loss}
 
     def validation_epoch_end(self, outputs):
         """
         Computes average validation accuracy
         """
-        avg_loss = torch.stack([x["val_loss"] for x in outputs]).mean()
-        tensorboard_logs = {"val_loss": avg_loss}
-        return {"avg_val_loss": avg_loss, "log": tensorboard_logs}
+        avg_loss = torch.stack([x["val_step_loss"] for x in outputs]).mean()
+        return {"val_loss": avg_loss}
 
     def test_step(self, test_batch, batch_idx):
         """

--- a/mlflow/pytorch/pytorch_autolog.py
+++ b/mlflow/pytorch/pytorch_autolog.py
@@ -31,9 +31,9 @@ class __MLflowPLCallback(pl.Callback):
         Log loss and other metrics values after each epoch
         """
         if (pl_module.current_epoch - 1) % self.every_n_iter == 0:
-            metrics = trainer.callback_metrics
+            self.metrics = trainer.callback_metrics
 
-            for key, value in metrics.items():
+            for key, value in self.metrics.items():
                 trainer.logger.experiment.log_metric(
                     trainer.logger.run_id,
                     key,
@@ -111,9 +111,10 @@ class __MLflowPLCallback(pl.Callback):
         metrics = trainer.callback_metrics
 
         for key, value in metrics.items():
-            trainer.logger.experiment.log_metric(
-                trainer.logger.run_id, key, float(value)
-            )
+            if key not in self.metrics:
+                trainer.logger.experiment.log_metric(
+                    trainer.logger.run_id, key, float(value)
+                )
 
     def _log_early_stop_params(self, trainer, early_stop_obj):
         """


### PR DESCRIPTION
…est end callback

## What changes are proposed in this pull request?

Changing key to val_loss and ignoring duplicate metrics logged during testing phase

## How is this patch tested?

Some tests similar to the Keras, fastai ones have been written to ensure model exporting and autologging works in most cases.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/python`: Python APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
