### PR TITLE
Pytorch Autolog Tests

### DIFF
--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -1,0 +1,87 @@
+import pytorch_lightning as pl
+from sklearn.metrics import accuracy_score
+from sklearn.datasets import load_iris
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, random_split, TensorDataset
+
+
+class IrisClassification(pl.LightningModule):
+    def __init__(self):
+        super(IrisClassification, self).__init__()
+        self.fc1 = nn.Linear(4, 10)
+        self.fc2 = nn.Linear(10, 10)
+        self.fc3 = nn.Linear(10, 3)
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = F.relu(self.fc3(x))
+        x = F.softmax(x, dim=1)
+        return x
+
+    def prepare_data(self):
+        iris = load_iris()
+        df = iris.data
+        target = iris["target"]
+
+        data = torch.Tensor(df).float()
+        labels = torch.Tensor(target).long()
+
+        data_set = TensorDataset(data, labels)
+        self.train_set, self.val_set = random_split(data_set, [130, 20])
+        self.train_set, self.test_set = random_split(self.train_set, [110, 20])
+
+    def train_dataloader(self):
+        train_loader = DataLoader(dataset=self.train_set, batch_size=8)
+        return train_loader
+
+    def val_dataloader(self):
+        validation_loader = DataLoader(dataset=self.val_set, batch_size=8)
+        return validation_loader
+
+    def test_dataloader(self):
+        test_loader = DataLoader(dataset=self.test_set, batch_size=8)
+        return test_loader
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=0.02)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self.forward(x)
+        loss = self.cross_entropy_loss(logits, y)
+
+        logs = {"loss": loss}
+        return {"loss": loss, "log": logs}
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self.forward(x)
+        loss = F.cross_entropy(logits, y)
+        return {"val_loss": loss}
+
+    def validation_epoch_end(self, outputs):
+        avg_loss = torch.stack([x["val_loss"] for x in outputs]).mean()
+        return {"val_loss": avg_loss}
+
+    def test_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self.forward(x)
+        loss = F.cross_entropy(logits, y)
+        a, y_hat = torch.max(logits, dim=1)
+        test_acc = accuracy_score(y_hat.cpu(), y.cpu())
+        return {"test_loss": loss, "test_acc": torch.tensor(test_acc)}
+
+    def test_epoch_end(self, outputs):
+        avg_loss = torch.stack([x["test_loss"] for x in outputs]).mean()
+        logs = {"test_loss": avg_loss}
+        avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
+        return {
+            "avg_test_loss": avg_loss,
+            "avg_test_acc": avg_test_acc,
+            "log": logs,
+            "progress_bar": logs,
+        }

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -77,11 +77,12 @@ class IrisClassification(pl.LightningModule):
 
     def test_epoch_end(self, outputs):
         avg_loss = torch.stack([x["test_loss"] for x in outputs]).mean()
-        logs = {"test_loss": avg_loss}
         avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
+        logs = {"test_loss": avg_loss, "test_acc" : avg_test_acc}
         return {
             "avg_test_loss": avg_loss,
             "avg_test_acc": avg_test_acc,
             "log": logs,
             "progress_bar": logs,
         }
+

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -78,11 +78,10 @@ class IrisClassification(pl.LightningModule):
     def test_epoch_end(self, outputs):
         avg_loss = torch.stack([x["test_loss"] for x in outputs]).mean()
         avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
-        logs = {"test_loss": avg_loss, "test_acc" : avg_test_acc}
+        logs = {"test_loss": avg_loss, "test_acc": avg_test_acc}
         return {
             "avg_test_loss": avg_loss,
             "avg_test_acc": avg_test_acc,
             "log": logs,
             "progress_bar": logs,
         }
-

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -1,7 +1,10 @@
+import os
 import pytest
 import pytorch_lightning as pl
 from iris import IrisClassification
 from mlflow.pytorch.pytorch_autolog import __MLflowPLCallback
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
+from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.logging import MLFlowLogger
 
 NUM_EPOCHS = 20
@@ -10,7 +13,7 @@ NUM_EPOCHS = 20
 @pytest.fixture
 def pytorch_model():
     mlflow_logger = MLFlowLogger(
-        tracking_uri="http://localhost:5000/", experiment_name="Default"
+        tracking_uri="http://localhost:5000"
     )
     model = IrisClassification()
     trainer = pl.Trainer(
@@ -53,3 +56,90 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
     artifacts = trainer.logger.experiment.list_artifacts(run.info.run_id)
     artifacts = map(lambda x: x.path, artifacts)
     assert "model_summary.txt" in artifacts
+
+
+@pytest.fixture
+def pytorch_model_with_callback(patience):
+    mlflow_logger = MLFlowLogger(
+        tracking_uri="http://localhost:5000"
+    )
+    model = IrisClassification()
+    early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
+
+    checkpoint_callback = ModelCheckpoint(
+        filepath=os.getcwd(),
+        save_top_k=1,
+        verbose=True,
+        monitor="val_loss",
+        mode="min",
+        prefix="",
+    )
+
+    trainer = pl.Trainer(
+        max_epochs=NUM_EPOCHS, callbacks=[__MLflowPLCallback()], logger=mlflow_logger, early_stop_callback=early_stopping, checkpoint_callback=checkpoint_callback
+    )
+    trainer.fit(model)
+    trainer.test()
+    client = trainer.logger.experiment
+    return trainer, client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('patience', [3])
+def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback, patience):
+    trainer, run = pytorch_model_with_callback
+    data = run.data
+    artifacts = trainer.logger.experiment.list_artifacts(run.info.run_id)
+    artifacts = map(lambda x: x.path, artifacts)
+    assert "restored_model_checkpoint" in artifacts
+
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('patience', [0, 1, 5])
+def test_pytorch_early_stop_params_logged(pytorch_model_with_callback, patience):
+    trainer, run = pytorch_model_with_callback
+    data = run.data
+    assert "monitor" in data.params
+    assert "mode" in data.params
+    assert "patience" in data.params
+    assert float(data.params["patience"]) == patience
+    assert "min_delta" in data.params
+    assert "stopped_epoch" in data.params
+
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('patience', [3])
+def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback, patience):
+    trainer, run = pytorch_model_with_callback
+    data = run.data
+    assert "Stopped_Epoch" in data.metrics
+    assert "Best_Score" in data.metrics
+    assert "Wait_Count" in data.metrics
+    assert "Restored_Epoch" in data.metrics
+
+
+@pytest.fixture
+def pytorch_model_tests():
+    mlflow_logger = MLFlowLogger(
+        tracking_uri="http://localhost:5000"
+    )
+    model = IrisClassification()
+
+    trainer = pl.Trainer(
+        max_epochs=NUM_EPOCHS, callbacks=[__MLflowPLCallback()], logger=mlflow_logger
+    )
+    trainer.fit(model)
+    trainer.test()
+    client = trainer.logger.experiment
+    return trainer, client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+
+
+@pytest.mark.large
+def test_pytorch_test_metrics_logged(pytorch_model_tests):
+    trainer, run = pytorch_model_tests
+    data = run.data
+    assert "test_loss" in data.metrics
+    assert "test_acc" in data.metrics
+

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -1,0 +1,55 @@
+import pytest
+import pytorch_lightning as pl
+from iris import IrisClassification
+from mlflow.pytorch.pytorch_autolog import __MLflowPLCallback
+from pytorch_lightning.logging import MLFlowLogger
+
+NUM_EPOCHS = 20
+
+
+@pytest.fixture
+def pytorch_model():
+    mlflow_logger = MLFlowLogger(
+        tracking_uri="http://localhost:5000/", experiment_name="Default"
+    )
+    model = IrisClassification()
+    trainer = pl.Trainer(
+        max_epochs=NUM_EPOCHS, callbacks=[__MLflowPLCallback()], logger=mlflow_logger
+    )
+    trainer.fit(model)
+    client = trainer.logger.experiment
+    return trainer, client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+
+
+@pytest.mark.large
+def test_pytorch_autolog_logs_default_params(pytorch_model):
+    trainer, run = pytorch_model
+    data = run.data
+    assert "learning_rate" in data.params
+    assert "epsilon" in data.params
+    assert "optimizer_name" in data.params
+
+
+@pytest.mark.large
+def test_pytorch_autolog_logs_expected_data(pytorch_model):
+    trainer, run = pytorch_model
+    data = run.data
+
+    # Testing metrics are logged
+    assert "loss" in data.metrics
+    assert "val_loss" in data.metrics
+
+    assert "epoch" in data.metrics
+    assert data.metrics["epoch"] == NUM_EPOCHS - 1
+
+    # Testing unwanted parameters are not logged
+    assert "callbacks" not in data.params
+
+    # Testing optimizer parameters are logged
+    assert "optimizer_name" in data.params
+    assert data.params["optimizer_name"] == "Adam"
+
+    # Testing model_summary.txt is saved
+    artifacts = trainer.logger.experiment.list_artifacts(run.info.run_id)
+    artifacts = map(lambda x: x.path, artifacts)
+    assert "model_summary.txt" in artifacts

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -12,9 +12,7 @@ NUM_EPOCHS = 20
 
 @pytest.fixture
 def pytorch_model():
-    mlflow_logger = MLFlowLogger(
-        tracking_uri="http://localhost:5000"
-    )
+    mlflow_logger = MLFlowLogger(tracking_uri="http://localhost:5000")
     model = IrisClassification()
     trainer = pl.Trainer(
         max_epochs=NUM_EPOCHS, callbacks=[__MLflowPLCallback()], logger=mlflow_logger
@@ -60,11 +58,11 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
 @pytest.fixture
 def pytorch_model_with_callback(patience):
-    mlflow_logger = MLFlowLogger(
-        tracking_uri="http://localhost:5000"
-    )
+    mlflow_logger = MLFlowLogger(tracking_uri="http://localhost:5000")
     model = IrisClassification()
-    early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
+    early_stopping = EarlyStopping(
+        monitor="val_loss", mode="min", patience=patience, verbose=True
+    )
 
     checkpoint_callback = ModelCheckpoint(
         filepath=os.getcwd(),
@@ -76,7 +74,11 @@ def pytorch_model_with_callback(patience):
     )
 
     trainer = pl.Trainer(
-        max_epochs=NUM_EPOCHS, callbacks=[__MLflowPLCallback()], logger=mlflow_logger, early_stop_callback=early_stopping, checkpoint_callback=checkpoint_callback
+        max_epochs=NUM_EPOCHS,
+        callbacks=[__MLflowPLCallback()],
+        logger=mlflow_logger,
+        early_stop_callback=early_stopping,
+        checkpoint_callback=checkpoint_callback,
     )
     trainer.fit(model)
     trainer.test()
@@ -85,7 +87,7 @@ def pytorch_model_with_callback(patience):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('patience', [3])
+@pytest.mark.parametrize("patience", [3])
 def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback, patience):
     trainer, run = pytorch_model_with_callback
     data = run.data
@@ -94,9 +96,8 @@ def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback, patience
     assert "restored_model_checkpoint" in artifacts
 
 
-
 @pytest.mark.large
-@pytest.mark.parametrize('patience', [0, 1, 5])
+@pytest.mark.parametrize("patience", [0, 1, 5])
 def test_pytorch_early_stop_params_logged(pytorch_model_with_callback, patience):
     trainer, run = pytorch_model_with_callback
     data = run.data
@@ -108,9 +109,8 @@ def test_pytorch_early_stop_params_logged(pytorch_model_with_callback, patience)
     assert "stopped_epoch" in data.params
 
 
-
 @pytest.mark.large
-@pytest.mark.parametrize('patience', [3])
+@pytest.mark.parametrize("patience", [3])
 def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback, patience):
     trainer, run = pytorch_model_with_callback
     data = run.data
@@ -122,9 +122,7 @@ def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback, patience
 
 @pytest.fixture
 def pytorch_model_tests():
-    mlflow_logger = MLFlowLogger(
-        tracking_uri="http://localhost:5000"
-    )
+    mlflow_logger = MLFlowLogger(tracking_uri="http://localhost:5000")
     model = IrisClassification()
 
     trainer = pl.Trainer(
@@ -142,4 +140,3 @@ def test_pytorch_test_metrics_logged(pytorch_model_tests):
     data = run.data
     assert "test_loss" in data.metrics
     assert "test_acc" in data.metrics
-


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding tests to validate default params and metrics

## How is this patch tested?

Some tests similar to the Keras, fastai ones have been written to ensure model exporting and autologging works in most cases.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [x] `language/python`: Python APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
