### PR TITLE
Fixing Mlflow log model

### DIFF
--- a/mlflow/pytorch/pytorch_autolog.py
+++ b/mlflow/pytorch/pytorch_autolog.py
@@ -91,6 +91,11 @@ class __MLflowPLCallback(pl.Callback):
         Logs the model checkpoint into mlflow - models folder on the training end
         """
 
+        # autolog method uses Pytorch Lightning's MLFLow logger for tracking metrics.
+        # Start and End run are controlled by MLFlowLogger class.
+        # Unless tracking URI and experiment are set explicitly, mlflow.pytorch will not be able to log the model.
+        # To fix this issue, logger variables such as tracking uri, experiment name and run id are used.
+        # Note: run_id parameter in start_run helps to log the model into the same run created by MLFLow logger.
         mlflow.set_tracking_uri(trainer.logger._tracking_uri )
         mlflow.set_experiment(trainer.logger._experiment_name)
         mlflow.start_run(trainer.logger.run_id)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Current version of autolog, saves the model locally and uploads it using log artifacts. Right approach is to use mlflow.pytorch.log_model. 

## How is this patch tested?

Tested with Mnist and Bert example. Model is getting logged into mlfow. 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [x] `language/r`: Python APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
