### PR TITLE
Adding early stopping parameters in command line argument and updatin…

### DIFF
--- a/examples/pytorch/MNIST/example1/MLproject
+++ b/examples/pytorch/MNIST/example1/MLproject
@@ -12,6 +12,10 @@ entry_points:
       num_workers: {type: int, default: 1}
       learning_rate: {type: float, default: 1e-3}
       tracking_uri: {type: str, default: 'http://localhost:5000'}
+      patience: {type int, default: 3}
+      mode: {type str, default: 'min'}
+      verbose: {type bool, default: True}
+      monitor: {type str, default: 'val_loss'}
 
     command: |
           python mnist_autolog_example1.py \
@@ -21,4 +25,8 @@ entry_points:
             --batch-size {batch_size} \
             --num-workers {num_workers} \
             --lr {learning_rate} \
-            --tracking_uri {tracking_uri}
+            --tracking_uri {tracking_uri} \
+            --es-patience {patience} \
+            --es-mode {mode} \
+            --es-verbose {verbose} \
+            --es-monitor {monitor}

--- a/examples/pytorch/MNIST/example1/README.md
+++ b/examples/pytorch/MNIST/example1/README.md
@@ -54,15 +54,16 @@ For example:
     --batch-size 64 \
     --num-workers 2 \
     --lr 0.01 \
-    --tracking_uri "http://localhost:5000"`
+    --tracking_uri "http://localhost:5000" \
+    --es-patience 5`
 
 Apart from model specific arguments, this example demonstrates early stopping behaviour.
-Following are the early stopping parameter set in the script - `mnist_autolog_example`
+Following are the early stopping parameter which can be set using command line argument
 
-1. monitor is set to `val_loss`
-2. mode is set to `min`
-3. patience is set to default value `3`
-4. verbose is set to `True`
+1. monitor is set to `val_loss` (--es-monitor)
+2. mode is set to `min` (--es-mode)
+3. patience is set to default value `3` (--es-patience)
+4. verbose is set to `True` (--es-verbose)
 
 
 Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -262,9 +262,7 @@ if __name__ == "__main__":
         "--es-monitor", type=str, default="val_loss", help="Early stopping monitor parameter"
     )
 
-    parser.add_argument(
-        "--es-mode", type=str, default="min", help="Early stopping mode parameter"
-    )
+    parser.add_argument("--es-mode", type=str, default="min", help="Early stopping mode parameter")
 
     parser.add_argument(
         "--es-verbose", type=bool, default=True, help="Early stopping verbose parameter"
@@ -283,8 +281,12 @@ if __name__ == "__main__":
     mlflow.set_tracking_uri(dict_args["tracking_uri"])
 
     model = LightningMNISTClassifier(**dict_args)
-    early_stopping = EarlyStopping(monitor=dict_args["es_monitor"], mode=dict_args["es_mode"],
-                                   verbose=dict_args["es_verbose"], patience=dict_args["es_patience"])
+    early_stopping = EarlyStopping(
+        monitor=dict_args["es_monitor"],
+        mode=dict_args["es_mode"],
+        verbose=dict_args["es_verbose"],
+        patience=dict_args["es_patience"],
+    )
 
     checkpoint_callback = ModelCheckpoint(
         filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -236,6 +236,25 @@ if __name__ == "__main__":
         default=None,
         help="Distributed Backend - (default: None)",
     )
+
+    # Early stopping parameters
+
+    parser.add_argument(
+        "--es-monitor", type=str, default="val_loss", help="Early stopping monitor parameter"
+    )
+
+    parser.add_argument(
+        "--es-mode", type=str, default="min", help="Early stopping mode parameter"
+    )
+
+    parser.add_argument(
+        "--es-verbose", type=bool, default=True, help="Early stopping verbose parameter"
+    )
+
+    parser.add_argument(
+        "--es-patience", type=int, default=3, help="Early stopping patience parameter"
+    )
+
     parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
 
     autolog()
@@ -245,7 +264,8 @@ if __name__ == "__main__":
     mlflow.set_tracking_uri(dict_args['tracking_uri'])
 
     model = LightningMNISTClassifier(**dict_args)
-    early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)
+    early_stopping = EarlyStopping(monitor=dict_args["es_monitor"], mode=dict_args["es_mode"],
+                                   verbose=dict_args["es_verbose"], patience=dict_args["es_patience"])
 
     checkpoint_callback = ModelCheckpoint(
         filepath=os.getcwd(),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding early stopping parameter to command line arguments and updating readme

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
