### PR TITLE
Autolog - Adding max epochs param

### DIFF
--- a/mlflow/pytorch/pytorch_autolog.py
+++ b/mlflow/pytorch/pytorch_autolog.py
@@ -36,9 +36,9 @@ def autolog(log_every_n_iter=1):
             """
             Log loss and other metrics values after each epoch
             """
-            if (pl_module.current_epoch - 1) % every_n_iter == 0:
+            if (pl_module.current_epoch + 1) % every_n_iter == 0:
                 for key, value in trainer.callback_metrics.items():
-                    try_mlflow_log(mlflow.log_metric, key, float(value), step=pl_module.current_epoch)
+                    try_mlflow_log(mlflow.log_metric, key, float(value + 1), step=pl_module.current_epoch)
 
             if trainer.early_stop_callback:
                 self._early_stop_check(trainer.early_stop_callback)
@@ -48,6 +48,7 @@ def autolog(log_every_n_iter=1):
             Logs Optimizer related metrics when the train begins
             """
             mlflow.set_tag(key="Mode", value="training")
+            try_mlflow_log(mlflow.log_param, "epochs", trainer.max_epochs)
             if trainer.early_stop_callback:
                 self._log_early_stop_params(trainer.early_stop_callback)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding max epochs param to autolog

## How is this patch tested?

Tested with examples

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
