### PR TITLE
[WIP] Adding Predict method in deployments cli and adding config parameter to delete deployment for passing ids

### DIFF
--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -135,12 +135,14 @@ class BaseDeploymentClient(abc.ABC):
 
     @abc.abstractmethod
     @experimental
-    def delete_deployment(self, name):
+    def delete_deployment(self, name, config):
         """
         Delete the deployment with name ``name`` from the specified target. Deletion should be
         idempotent (i.e. deletion should not fail if retried on a non-existent deployment).
 
         :param name: Name of deployment to delete
+        :param config: (optional) dict containing updated target-specific configuration for the
+                       deployment
         :return: None
         """
         pass

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -171,14 +171,16 @@ def update_deployment(flavor, model_uri, target, name, config):
 
 
 @commands.command("delete")
+@parse_custom_arguments
 @deployment_name
 @target_details
-def delete_deployment(target, name):
+def delete_deployment(target, name, config):
     """
     Delete the deployment with name given at `--name` from the specified target.
     """
+    config_dict = _user_args_to_dict(config)
     client = interface.get_deploy_client(target)
-    client.delete_deployment(name)
+    client.delete_deployment(name, config_dict)
     click.echo("Deployment {} is deleted".format(name))
 
 

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -173,7 +173,7 @@ def update_deployment(flavor, model_uri, target, name, config):
 @commands.command("delete")
 @deployment_name
 @target_details
-def delete_deployment(target, name, config=None):
+def delete_deployment(target, name):
     """
     Delete the deployment with name given at `--name` from the specified target.
     """

--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -171,16 +171,14 @@ def update_deployment(flavor, model_uri, target, name, config):
 
 
 @commands.command("delete")
-@parse_custom_arguments
 @deployment_name
 @target_details
-def delete_deployment(target, name, config):
+def delete_deployment(target, name, config=None):
     """
     Delete the deployment with name given at `--name` from the specified target.
     """
-    config_dict = _user_args_to_dict(config)
     client = interface.get_deploy_client(target)
-    client.delete_deployment(name, config_dict)
+    client.delete_deployment(name)
     click.echo("Deployment {} is deleted".format(name))
 
 

--- a/tests/deployments/test_cli.py
+++ b/tests/deployments/test_cli.py
@@ -1,3 +1,4 @@
+import tempfile
 from click.testing import CliRunner
 from mlflow.deployments import cli
 
@@ -73,6 +74,18 @@ def test_get():
     res = runner.invoke(cli.get_deployment, ["--name", f_name, "--target", f_target])
     assert "key1: val1" in res.stdout
     assert "key2: val2" in res.stdout
+
+
+def test_predict():
+    temp_input_file = tempfile.NamedTemporaryFile('w+t')
+    temp_input_file.name = "input.json"
+    temp_input_file.write('{"data": [5000]}')
+    temp_input_file.seek(0)
+    runner = CliRunner()
+    res = runner.invoke(cli.predict,
+                        ['--target', f_target, '--name', f_name, '--input_path', temp_input_file, '--output_path', 'sample.json'])
+    assert "RESULT IS: {}".format(str(1)) in res.stdout
+    temp_input_file.close()
 
 
 def test_target_help():

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -24,7 +24,7 @@ def test_create_success():
 
 def test_delete_success():
     client = deployments.get_deploy_client(f_target)
-    assert client.delete_deployment(f_deployment_id) is None
+    assert client.delete_deployment(f_deployment_id, config={}) is None
 
 
 def test_update_success():

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
@@ -10,7 +10,7 @@ class PluginDeploymentClient(BaseDeploymentClient):
             raise RuntimeError("Error requested")
         return {"name": f_deployment_name, "flavor": flavor}
 
-    def delete_deployment(self, name):
+    def delete_deployment(self, name, config):
         return None
 
     def update_deployment(self, name, model_uri=None, flavor=None, config=None):
@@ -24,8 +24,8 @@ class PluginDeploymentClient(BaseDeploymentClient):
     def get_deployment(self, name):
         return {"key1": "val1", "key2": "val2"}
 
-    def predict(self, deployment_name, df):
-        return 1
+    def predict(self, deployment_name, df, config=None):
+        return '1'
 
 
 def run_local(name, model_uri, flavor=None, config=None):


### PR DESCRIPTION

## What changes are proposed in this pull request?

Current cli version doesnt support predict. Adding new predict method to abstract class. This predict method can be overriden in the subclasses to perform prediction. 

In torchserve, the delete deployment api takes version number as input. Current cli delete method doesnt take any argument as input. Adding config variable to pass ids. 

## How is this patch tested?

Tested with deployment examples. 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
