### PR TITLE
Fix to log mlflow only on rank zero - ddp environment

### DIFF
--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -36,7 +36,7 @@ class MNISTDataModule(pl.LightningDataModule):
         self.val_data_loader = None
         self.test_data_loader = None
         self.args = kwargs
-        
+
         # transforms for images
         self.transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
@@ -49,9 +49,13 @@ class MNISTDataModule(pl.LightningDataModule):
         :param stage: Stage - training or testing
         """
 
-        self.df_train = datasets.MNIST("dataset", download=True, train=True, transform=self.transform)
+        self.df_train = datasets.MNIST(
+            "dataset", download=True, train=True, transform=self.transform
+        )
         self.df_train, self.df_val = random_split(self.df_train, [55000, 5000])
-        self.df_test = datasets.MNIST("dataset", download=True, train=False, transform=self.transform)
+        self.df_test = datasets.MNIST(
+            "dataset", download=True, train=False, transform=self.transform
+        )
 
     @staticmethod
     def add_model_specific_args(parent_parser):
@@ -108,6 +112,7 @@ class MNISTDataModule(pl.LightningDataModule):
         :return: output - Test data loader for the given input
         """
         return self.create_data_loader(self.df_test)
+
 
 class LightningMNISTClassifier(pl.LightningModule):
     def __init__(self, **kwargs):
@@ -351,9 +356,7 @@ if __name__ == "__main__":
     lr_logger = LearningRateMonitor()
 
     trainer = pl.Trainer.from_argparse_args(
-        args,
-        callbacks=[lr_logger, early_stopping],
-        checkpoint_callback=checkpoint_callback
+        args, callbacks=[lr_logger, early_stopping], checkpoint_callback=checkpoint_callback
     )
     trainer.fit(model, dm)
     trainer.test()

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -5,8 +5,9 @@
 # pytorch-lightning (using pip install pytorch-lightning)
 #       and mlflow (using pip install mlflow).
 #
-# pylint: disable=W0221
-# pylint: disable=W0613
+# pylint: disable=arguments-differ
+# pylint: disable=unused-argument
+# pylint: disable=abstract-method
 import pytorch_lightning as pl
 import os
 import mlflow
@@ -22,6 +23,92 @@ from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
 
 
+class MNISTDataModule(pl.LightningDataModule):
+    def __init__(self, **kwargs):
+        """
+        Initialization of inherited lightning data module
+        """
+        super(MNISTDataModule, self).__init__()
+        self.df_train = None
+        self.df_val = None
+        self.df_test = None
+        self.train_data_loader = None
+        self.val_data_loader = None
+        self.test_data_loader = None
+        self.args = kwargs
+        
+        # transforms for images
+        self.transform = transforms.Compose(
+            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+        )
+
+    def setup(self, stage=None):
+        """
+        Downloads the data, parse it and split the data into train, test, validation data
+
+        :param stage: Stage - training or testing
+        """
+
+        self.df_train = datasets.MNIST("dataset", download=True, train=True, transform=self.transform)
+        self.df_train, self.df_val = random_split(self.df_train, [55000, 5000])
+        self.df_test = datasets.MNIST("dataset", download=True, train=False, transform=self.transform)
+
+    @staticmethod
+    def add_model_specific_args(parent_parser):
+        """
+        Returns the review text and the targets of the specified item
+
+        :param parent_parser: Application specific parser
+
+        :return: Returns the augmented arugument parser
+        """
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=16,
+            metavar="N",
+            help="input batch size for training (default: 16)",
+        )
+        parser.add_argument(
+            "--num-workers",
+            type=int,
+            default=3,
+            metavar="N",
+            help="number of workers (default: 0)",
+        )
+        return parser
+
+    def create_data_loader(self, df):
+        """
+        Generic data loader function
+
+        :param df: Input tensor
+
+        :return: Returns the constructed dataloader
+        """
+        return DataLoader(
+            df, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
+        )
+
+    def train_dataloader(self):
+        """
+        :return: output - Train data loader for the given input
+        """
+        return self.create_data_loader(self.df_train)
+
+    def val_dataloader(self):
+        """
+        :return: output - Validation data loader for the given input
+        """
+        return self.create_data_loader(self.df_val)
+
+    def test_dataloader(self):
+        """
+        :return: output - Test data loader for the given input
+        """
+        return self.create_data_loader(self.df_test)
+
 class LightningMNISTClassifier(pl.LightningModule):
     def __init__(self, **kwargs):
         """
@@ -36,11 +123,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         self.layer_2 = torch.nn.Linear(128, 256)
         self.layer_3 = torch.nn.Linear(256, 10)
         self.args = kwargs
-
-        # transforms for images
-        self.transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
-        )
 
     @staticmethod
     def add_model_specific_args(parent_parser):
@@ -170,35 +252,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         """
         return {}
 
-    def train_dataloader(self):
-        """
-        :return: output - Train data loader for the given input
-        """
-        mnist_train = datasets.MNIST("dataset", download=True, train=True, transform=self.transform)
-        return DataLoader(
-            mnist_train, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
-        )
-
-    def val_dataloader(self):
-        """
-        :return: output - Validation data loader for the given input
-        """
-        mnist_train = datasets.MNIST("dataset", download=True, train=True, transform=self.transform)
-        mnist_train, mnist_val = random_split(mnist_train, [55000, 5000])
-
-        return DataLoader(
-            mnist_val, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
-        )
-
-    def test_dataloader(self):
-        """
-        :return: output - Test data loader for the given input
-        """
-        mnist_test = datasets.MNIST("dataset", download=True, train=False, transform=self.transform)
-        return DataLoader(
-            mnist_test, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
-        )
-
     def configure_optimizers(self):
         """
         Initializes the optimizer and learning rate scheduler
@@ -280,6 +333,11 @@ if __name__ == "__main__":
     mlflow.set_tracking_uri(dict_args["tracking_uri"])
 
     model = LightningMNISTClassifier(**dict_args)
+
+    dm = MNISTDataModule(**dict_args)
+    dm.prepare_data()
+    dm.setup(stage="fit")
+
     early_stopping = EarlyStopping(
         monitor=dict_args["es_monitor"],
         mode=dict_args["es_mode"],
@@ -295,8 +353,7 @@ if __name__ == "__main__":
     trainer = pl.Trainer.from_argparse_args(
         args,
         callbacks=[lr_logger, early_stopping],
-        checkpoint_callback=checkpoint_callback,
-        limit_train_batches=0.1,
+        checkpoint_callback=checkpoint_callback
     )
-    trainer.fit(model)
+    trainer.fit(model, dm)
     trainer.test()

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -18,6 +18,7 @@ from torch.nn import functional as F
 from torch.utils.data import DataLoader, random_split
 from torchvision import datasets, transforms
 
+
 class MNISTDataModule(pl.LightningDataModule):
     def __init__(self, **kwargs):
         """
@@ -31,7 +32,7 @@ class MNISTDataModule(pl.LightningDataModule):
         self.val_data_loader = None
         self.test_data_loader = None
         self.args = kwargs
-        
+
         # transforms for images
         self.transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
@@ -50,9 +51,13 @@ class MNISTDataModule(pl.LightningDataModule):
         :param stage: Stage - training or testing
         """
 
-        self.df_train = datasets.MNIST("dataset", download=True, train=True, transform=self.transform)
+        self.df_train = datasets.MNIST(
+            "dataset", download=True, train=True, transform=self.transform
+        )
         self.df_train, self.df_val = random_split(self.df_train, [55000, 5000])
-        self.df_test = datasets.MNIST("dataset", download=True, train=False, transform=self.transform)
+        self.df_test = datasets.MNIST(
+            "dataset", download=True, train=False, transform=self.transform
+        )
 
     @staticmethod
     def add_model_specific_args(parent_parser):

--- a/mlflow/pytorch/pytorch_autolog.py
+++ b/mlflow/pytorch/pytorch_autolog.py
@@ -6,6 +6,7 @@ import pytorch_lightning as pl
 import shutil
 import tempfile
 from pytorch_lightning.core.memory import ModelSummary
+from pytorch_lightning.utilities import rank_zero_only
 from mlflow.utils.autologging_utils import try_mlflow_log
 
 logging.basicConfig(level=logging.ERROR)
@@ -26,6 +27,7 @@ every_n_iter = 1
 # tracking uri, experiment_id and run_id which may lead to a race condition.
 
 
+@rank_zero_only
 def autolog(log_every_n_iter=1):
     global every_n_iter
     every_n_iter = log_every_n_iter


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix for logging into mlflow only on rank zero

## How is this patch tested?

Tested with examples

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
