### PR TITLE
PyTorch Automatic Logging Documentation

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -302,6 +302,7 @@ for installation instructions, and see the
 for usage instructions and examples.
 
 - `mlflow-redisai <https://github.com/RedisAI/mlflow-redisai>`_
+- `mlflow-torchserve <https://github.com/chauhang/mlflow/tree/feature-torchserve-plugin/mlflow/pytorch/torchserve>`_
 
 
 Project Backend Plugins
@@ -311,3 +312,14 @@ The following known plugins provide support for running `MLflow projects <https:
 against custom execution backends.
 
 - `mlflow-yarn <https://github.com/criteo/mlflow-yarn>`_ Running mlflow on Hadoop/YARN
+
+Tracking Store Plugins
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The following known plugins provide support for running `MLflow Tracking Store <https://www.mlflow.org/docs/latest/tracking.html>`_
+against custom databases.
+
+- `mlflow-elasticsearchstore <https://github.com/criteo/mlflow-elasticsearchstore>`_ Running MLflow Tracking Store with Elasticsearch
+
+This plugin is experimental please refer to <https://github.com/criteo/mlflow-elasticsearchstore/issues> to have the list of limitations.
+Library is available on PyPI here : <https://pypi.org/project/mlflow-elasticsearchstore/>low

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -302,7 +302,7 @@ for installation instructions, and see the
 for usage instructions and examples.
 
 - `mlflow-redisai <https://github.com/RedisAI/mlflow-redisai>`_
-- `mlflow-torchserve <https://github.com/chauhang/mlflow/tree/feature-torchserve-plugin/mlflow/pytorch/torchserve>`_
+- `mlflow-torchserve <https://github.com/mlflow/mlflow-torchserve>`_
 
 
 Project Backend Plugins

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -302,7 +302,7 @@ for installation instructions, and see the
 for usage instructions and examples.
 
 - `mlflow-redisai <https://github.com/RedisAI/mlflow-redisai>`_
-- `mlflow-torchserve <https://github.com/mlflow/mlflow-torchserve>`_
+
 
 
 Project Backend Plugins

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -432,10 +432,10 @@ Autologging captures the following information:
 Pytorch (experimental)
 --------------------------
 
-Call :py:func:`mlflow.pytorch.autolog` before your training code to enable automatic logging of metrics and parameters. See example usages with `Pytorch <https://github.com/chauhang/mlflow/tree/master/examples/pytorch/MNIST>`_.
+Call :py:func:`mlflow.pytorch.autolog` before your training code to enable automatic logging of metrics and parameters. See example usages with `Pytorch <https://github.com/mlflow/mlflow/tree/master/examples/pytorch>`_.
 
 Whether you are using torch 1.5 or 1.6, the respective metrics associated with ``EarlyStopping Callabacks`` and ``pytorch_lightning.trainer`` are automatically logged.
-As an example, try running the `MLflow Pytorch examples <https://github.com/chauhang/mlflow/tree/master/examples/pytorch/MNIST>`_.
+As an example, try running the `MLflow Pytorch examples <https://github.com/mlflow/mlflow/tree/master/examples/pytorch>`_.
 
 Autologging captures the following information:
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -218,11 +218,19 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
   X-axis relative time - graphs the time relative to the first metric logged, for each run
 
 
+.. _automatic-logging:
+
 Automatic Logging
 =================
 
-Automatic logging allows you to log metrics, parameters, and models without the need for explicit
-log statements, and is currently supported for:
+Automatic logging allows you to log metrics, parameters, and models without the need for explicit log statements.
+
+There are two ways to use autologging:
+
+#. Call :py:func:`mlflow.autolog` before your training code. This will enable autologging for each supported library you have installed as soon as you import it.
+#. Use library-specific autolog calls for each library you use in your code. See below for examples.
+
+The following libraries support autologging:
 
 .. contents::
   :local:
@@ -420,6 +428,41 @@ Autologging captures the following information:
 |           |                        | Logs the parameters of the `EarlyStoppingCallback`_ and  |               |                                                                                                                                                                       |
 |           |                        | `OneCycleScheduler`_ callbacks                           |               |                                                                                                                                                                       |
 +-----------+------------------------+----------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Pytorch (experimental)
+--------------------------
+
+Call :py:func:`mlflow.pytorch.autolog` before your training code to enable automatic logging of metrics and parameters. See example usages with `Pytorch <https://github.com/chauhang/mlflow/tree/master/examples/pytorch/MNIST>`_.
+
+Whether you are using torch 1.5 or 1.6, the respective metrics associated with ``EarlyStopping Callabacks`` and ``pytorch_lightning.trainer`` are automatically logged.
+As an example, try running the `MLflow Pytorch examples <https://github.com/chauhang/mlflow/tree/master/examples/pytorch/MNIST>`_.
+
+Autologging captures the following information:
+
++------------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+| Framework/module                         | Metrics                                                    | Parameters                                                                          | Tags          | Artifacts                                                                                                                                     |
++------------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+| ``trainer.callbacks.earlystopping``      | Training loss; validation loss;average_test_accuracy;      | ``fit()`` parameters; optimizer name; learning rate; epsilon.                       | --            | Model summary on training start; `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ (Pytorch model) on training end                 |
+|                                          | user-defined-metrics.                                      |                                                                                     |               | Also facilitates logging of torchscript models.                                                                                               |
+|                                          | Metrics from the ``EarlyStopping`` callbacks.              | Parameters associated with ``EarlyStopping``.                                       |               | Optional Documents such as ExtraFiles,requirements.txt on Training End could also be logged.                                                  |
+|                                          | For example, ``stopped_epoch``, ``restored_epoch``,        | For example, ``min_delta``, ``patience``, ``baseline``,                             |               | Best Pytorch model  Checkpoint if training stops due to early stopping callback.                                                              |
+|                                          | ``restore_best_weight``, etc.                              | ``restore_best_weights``, etc                                                       |               |                                                                                                                                               |
++------------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+| ``trainer``                              |Training loss;validation loss;average_test_accuracy;        | ``fit()`` parameters; optimizer name; learning rate; epsilon                        | --            | Model summary on training start; `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ (Pytorch model) on training end                 |
+|                                          |user-defined-metrics.                                       |                                                                                     |               | Also facilitates logging of torchscript models.                                                                                               |
+|                                          |                                                            |                                                                                     |               | Optional Documents such as ExtraFiles,requirements.txt on Training End could also be logged                                                   |
+|                                          |                                                            |                                                                                     |               |                                                                                                                                               |
++------------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
+
+If no active run exists when ``autolog()`` captures data, MLflow will automatically create a run to log information.
+Also, MLflow will then automatically end the run once training ends via calls to  ``pytorch_lightning.trainer.fit()`` or once ``pytorch`` models are exported via ``mlflow.pytorch.log_model()``.
+
+If a run already exists when ``autolog()`` captures data, MLflow will log to that run but not automatically end that run after training.
+
+.. note::
+  - Parameters not explicitly passed by users (parameters that use default values) while using ``pytorch_lightning.trainer.fit()`` are not currently automatically logged.
+  - This feature is experimental - the API and format of the logged data are subject to change
+
 
 .. _organizing_runs_in_experiments:
 
@@ -877,4 +920,4 @@ internal use. The following tags are set automatically by MLflow, when appropria
 | ``mlflow.log-model.history``  | (Experimental) Model metadata collected by log-model calls. Includes the serialized    |
 |                               | form of the MLModel model files logged to a run, although the exact format and         |
 |                               | information captured is subject to change.                                             |
-+-------------------------------+----------------------------------------------------------------------------------------+
++-------------------------------+---------------------------------------------------------------------------------------rc

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -434,7 +434,8 @@ Pytorch (experimental)
 
 Call :py:func:`mlflow.pytorch.autolog` before your training code to enable automatic logging of metrics and parameters. See example usages with `Pytorch <https://github.com/mlflow/mlflow/tree/master/examples/pytorch>`_.
 
-Whether you are using torch 1.5 or 1.6, the respective metrics associated with ``EarlyStopping Callabacks`` and ``pytorch_lightning.trainer`` are automatically logged.
+In the current implementation pytorch autolog works with `Lightning training loop <https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pytorch_lightning/trainer/training_loop.py>`_  and automatically logs the respective parameters,metrics associated with ``EarlyStopping Callabacks`` and ``pytorch_lightning.trainer`` in addition to the model and its summary.
+
 As an example, try running the `MLflow Pytorch examples <https://github.com/mlflow/mlflow/tree/master/examples/pytorch>`_.
 
 Autologging captures the following information:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updating pytorch autolog documentation.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
