### PR TITLE
[DO NOT MERGE] Adding mlflow.pytorch.save_state_dict and mlflow.pytorch.load_state_dict methods

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -79,6 +79,7 @@ def log_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     requirements_file=None,
     extra_files=None,
+    save_as_state_dict=False,
     **kwargs
 ):
     """
@@ -236,6 +237,7 @@ def log_model(
         await_registration_for=await_registration_for,
         requirements_file=requirements_file,
         extra_files=extra_files,
+        save_as_state_dict=save_as_state_dict,
         **kwargs,
     )
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -241,7 +241,18 @@ def log_model(
         **kwargs,
     )
 
+
 def save_state_dict(pytorch_model, path, **kwargs):
+    """
+    Save the model as state dict to a path on the local file system
+
+    :param pytorch_model: PyTorch model to be saved. Can be either an eager model (subclass of
+                          ``torch.nn.Module``) or scripted model prepared via ``torch.jit.script``
+                          or ``torch.jit.trace``.
+    :param path: Local path where the model is to be saved.
+    :param kwargs: kwargs to pass to ``torch.save`` method.
+    """
+
     save_model(pytorch_model, path, save_as_state_dict=True, **kwargs)
 
 
@@ -462,6 +473,7 @@ def save_model(
         FLAVOR_NAME,
         model_data=model_data_subpath,
         pytorch_version=torch.__version__,
+        state_dict=save_as_state_dict,
         **torchserve_artifacts_config,
     )
     pyfunc.add_to_model(
@@ -525,7 +537,27 @@ def _load_model(path, **kwargs):
 
 
 def load_state_dict(model_uri, model_class_obj):
+    """
+    Load a PyTorch model state dict from a local file or a run.
+
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                    - ``/Users/me/path/to/local/model``
+                    - ``relative/path/to/local/model``
+                    - ``s3://my_bucket/path/to/model``
+                    - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                    - ``models:/<model_name>/<model_version>``
+                    - ``models:/<model_name>/<stage>``
+
+                    For more information about supported URI schemes, see
+                    `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+                    artifact-locations>`_.
+    :param model_class_obj: Instance of the model class
+
+    :return: A pytorch model instance
+    """
     import torch
+
     model_path = load_model(model_uri, load_state_dict=True)
     model_path = os.path.join(model_path, _SERIALIZED_TORCH_MODEL_FILE_NAME)
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -138,7 +138,7 @@ def _autolog(log_every_n_epoch=1):
             :param pl_module: pytorch lightning base module
             """
 
-            mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
+            mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model", save_as_state_dict=True)
 
             if self.early_stopping and trainer.checkpoint_callback.best_model_path:
                 try_mlflow_log(

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -9,10 +9,6 @@ from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
 from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch
 from mlflow.utils.annotations import experimental
-from pytorch_lightning.overrides.data_parallel import (
-    LightningDistributedDataParallel,
-    LightningDataParallel,
-)
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -141,12 +137,7 @@ def _autolog(log_every_n_epoch=1):
             :param trainer: pytorch lightning trainer instance
             :param pl_module: pytorch lightning base module
             """
-
-            is_dp_module = isinstance(
-                trainer.model, (LightningDistributedDataParallel, LightningDataParallel)
-            )
-            model = trainer.model.module if is_dp_module else trainer.model
-            mlflow.pytorch.log_model(pytorch_model=model, artifact_path="model", save_as_state_dict=True)
+            mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
 
             if self.early_stopping and trainer.checkpoint_callback.best_model_path:
                 try_mlflow_log(

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -137,6 +137,7 @@ def _autolog(log_every_n_epoch=1):
             :param trainer: pytorch lightning trainer instance
             :param pl_module: pytorch lightning base module
             """
+
             mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
 
             if self.early_stopping and trainer.checkpoint_callback.best_model_path:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -9,6 +9,10 @@ from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
 from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch
 from mlflow.utils.annotations import experimental
+from pytorch_lightning.overrides.data_parallel import (
+    LightningDistributedDataParallel,
+    LightningDataParallel,
+)
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -138,7 +142,11 @@ def _autolog(log_every_n_epoch=1):
             :param pl_module: pytorch lightning base module
             """
 
-            mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model", save_as_state_dict=True)
+            is_dp_module = isinstance(
+                trainer.model, (LightningDistributedDataParallel, LightningDataParallel)
+            )
+            model = trainer.model.module if is_dp_module else trainer.model
+            mlflow.pytorch.log_model(pytorch_model=model, artifact_path="model", save_as_state_dict=True)
 
             if self.early_stopping and trainer.checkpoint_callback.best_model_path:
                 try_mlflow_log(


### PR DESCRIPTION

Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Adding support for saving the pytorch model's state dict. 

## How is this patch tested?

Tested both entire model and state dict version

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
