### PR TITLE
Adding Ax-HPO example for PTL

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/AxHyperOptimizationPTL.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/AxHyperOptimizationPTL.py
@@ -1,0 +1,74 @@
+import argparse
+import mlflow
+from ax.service.ax_client import AxClient
+import classifier
+import pytorch_lightning as pl
+
+
+def model_training_hyperparameter_tuning(max_epochs, total_trials, params):
+    """
+     This function takes input params max_epcohs.epxeirment_name,total_trials,params and tracking_uri
+     and creates a nested run in Mlflow.  The parameters,metrics,model and summary are dumped into their
+     respective mlflow-run ids. The best parameters are dumped along with the basedline model.
+
+    :param max_epochs:Max epochs used for training the model. Type:int
+    :param experiment_name: Mlflow experiment name , in which the runs would be logged. Type:str
+    :param total_trials: Number of ax-client experimental trials. Type:int
+    :param params: Model parameters. Type:dict
+    :param tracking_uri: Mlflow tracking_uri
+    """
+    mlflow.start_run(run_name="Parent Run")
+    dm = classifier.DataModule()
+    model = classifier.LeNet(kwargs=params)
+    classifier.train_evaluate(dm=dm, model=model, max_epochs=max_epochs)
+
+    ax_client = AxClient()
+    ax_client.create_experiment(
+        parameters=[
+            {"name": "lr", "type": "range", "bounds": [1e-3, 0.15], "log_scale": True},
+            {"name": "weight_decay", "type": "range", "bounds": [1e-4, 1e-3]},
+            {"name": "nesterov", "type": "choice", "values": [True, False]},
+            {"name": "momentum", "type": "range", "bounds": [0.7, 1.0]},
+        ],
+        objective_name="test_accuracy",
+    )
+
+    total_trials = total_trials
+
+    for i in range(total_trials):
+        with mlflow.start_run(nested=True, run_name="Trial " + str(i)) as child_run:
+            parameters, trial_index = ax_client.get_next_trial()
+            dm = classifier.DataModule()
+            model = classifier.LeNet(kwargs=parameters)
+            # calling the model
+            test_accuracy = classifier.train_evaluate(
+                parameterization=None, dm=dm, model=model, max_epochs=max_epochs
+            )
+
+            # completion of trial
+            ax_client.complete_trial(trial_index=trial_index, raw_data=test_accuracy.item())
+
+    best_parameters, metrics = ax_client.get_best_parameters()
+    for param_name, value in best_parameters.items():
+        mlflow.log_param("optimum " + param_name, value)
+
+    mlflow.end_run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
+
+    parser.add_argument(
+        "--total_trials",
+        default=3,
+        help="It indicated number of trials to be run for the optimization experiment",
+    )
+
+    args = parser.parse_args()
+
+    params = {"lr": 0.011, "momentum": 0.9, "weight_decay": 0, "nesterov": False}
+
+    model_training_hyperparameter_tuning(
+        max_epochs=int(args.max_epochs), total_trials=int(args.total_trials), params=params
+    )

--- a/examples/pytorch/AxHyperOptimizationPTL/MLproject
+++ b/examples/pytorch/AxHyperOptimizationPTL/MLproject
@@ -1,0 +1,16 @@
+name: axbotorch-hyperparameter-optimization
+
+conda_env: conda.yaml
+
+entry_points:
+  main:
+    parameters:
+      max_epochs: {type: int, default: 3}
+      total_trials: {type: int, default: 3}
+
+
+    command: |
+          python AxHyperOptimizationPTL.py \
+            --max_epochs {max_epochs} \
+            --total_trials {total_trials} \
+

--- a/examples/pytorch/AxHyperOptimizationPTL/MLproject
+++ b/examples/pytorch/AxHyperOptimizationPTL/MLproject
@@ -13,4 +13,3 @@ entry_points:
           python AxHyperOptimizationPTL.py \
             --max_epochs {max_epochs} \
             --total_trials {total_trials} \
-

--- a/examples/pytorch/AxHyperOptimizationPTL/MLproject
+++ b/examples/pytorch/AxHyperOptimizationPTL/MLproject
@@ -12,4 +12,4 @@ entry_points:
     command: |
           python AxHyperOptimizationPTL.py \
             --max_epochs {max_epochs} \
-            --total_trials {total_trials} \
+            --total_trials {total_trials}

--- a/examples/pytorch/AxHyperOptimizationPTL/README.md
+++ b/examples/pytorch/AxHyperOptimizationPTL/README.md
@@ -1,0 +1,70 @@
+## Ax Hyperparameter Optimization Example 
+In this example, we train a Pytorch Lightning model to classify [CIFAR-10 dataset](https://github.com/pytorch/vision/blob/master/torchvision/datasets/cifar.py). The code, adapted from this [repository](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html), is almost entirely dedicated to model training and hyperparameter optimization.
+A parent run will be created during the training process,which would dump the baseline model and relevant parameters,metrics and model along with its summary,subsequently followed by a set of nested child runs, which will dump the trial results.
+The best parameters would be dumped into the parent run once the experiments are completed.
+
+## Package Requirement
+
+Install the required packages using the following command
+
+`pip install -r requirements.txt`
+
+### Running the code
+To run the example via MLflow, navigate to the `mlflow/examples/pytorch/axbotorch` directory and run the command
+
+```
+mlflow run .
+```
+
+This will run `AxHyperOptimizationPTL.py` with the default set of parameters such as  `--max_epochs=3` and `total_trials=3`. You can see the default value in the `MLproject` file.
+
+In order to run the file with custom parameters, run the command
+
+```
+mlflow run . -P max_epochs=X -P total_trails = Y
+```
+
+where `X` is your desired value for `max_epochs` and `Y` is your desired value for `total_trials`.
+
+If you have the required modules for the file and would like to skip the creation of a conda environment, add the argument `--no-conda`.
+
+```
+mlflow run . --no-conda
+
+```
+
+### Viewing results in the MLflow UI
+
+Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
+
+```
+mlflow ui
+```
+
+and navigating to [http://localhost:5000](http://localhost:5000).
+
+For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
+
+### Passing custom training parameters
+
+The parameters can be overridden via the command line:
+
+1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
+2. total_trials - Number of experimental trials
+
+
+For example:
+```
+mlflow run . -P max_epochs=3 -P total_trials=3
+```
+Or to run the training script directly with custom parameters:
+
+```
+python AxHyperOptimizationPTL.py \
+    --max_epochs 3 \
+    --total_trials 3 \
+```
+
+
+## Logging to a custom tracking server
+To configure MLflow to log to a custom (non-default) tracking location, set the MLFLOW_TRACKING_URI environment variable, e.g. via export MLFLOW_TRACKING_URI=http://localhost:5000/. For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).

--- a/examples/pytorch/AxHyperOptimizationPTL/README.md
+++ b/examples/pytorch/AxHyperOptimizationPTL/README.md
@@ -3,12 +3,6 @@ In this example, we train a Pytorch Lightning model to classify [CIFAR-10 datase
 A parent run will be created during the training process,which would dump the baseline model and relevant parameters,metrics and model along with its summary,subsequently followed by a set of nested child runs, which will dump the trial results.
 The best parameters would be dumped into the parent run once the experiments are completed.
 
-## Package Requirement
-
-Install the required packages using the following command
-
-`pip install -r requirements.txt`
-
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/axbotorch` directory and run the command
 

--- a/examples/pytorch/AxHyperOptimizationPTL/README.md
+++ b/examples/pytorch/AxHyperOptimizationPTL/README.md
@@ -15,7 +15,7 @@ This will run `AxHyperOptimizationPTL.py` with the default set of parameters suc
 In order to run the file with custom parameters, run the command
 
 ```
-mlflow run . -P max_epochs=X -P total_trails = Y
+mlflow run . -P max_epochs=X -P total_trials = Y
 ```
 
 where `X` is your desired value for `max_epochs` and `Y` is your desired value for `total_trials`.

--- a/examples/pytorch/AxHyperOptimizationPTL/classifier.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/classifier.py
@@ -1,0 +1,165 @@
+import mlflow.pytorch
+import pytorch_lightning as pl
+import torch
+import torch.nn as nn
+import torchvision
+from mlflow.utils.autologging_utils import try_mlflow_log
+from sklearn.metrics import accuracy_score
+from torch.nn import functional as F
+from torch.utils.data import DataLoader
+from torch.utils.data.dataset import random_split
+from torchvision import transforms
+from pytorch_lightning.metrics.functional import accuracy
+
+
+class DataModule(pl.LightningDataModule):
+    def __init__(self):
+        super().__init__()
+        self.train_transforms = transforms.Compose(
+            [
+                transforms.RandomCrop(32, padding=4),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+            ]
+        )
+        self.test_transforms = transform_test = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+            ]
+        )
+
+    def prepare_data(self):
+        trainset = torchvision.datasets.CIFAR10(
+            root="./CIFAR10", train=True, download=True, transform=self.train_transforms
+        )
+        testset = torchvision.datasets.CIFAR10(
+            root="./CIFAR10", train=False, download=True, transform=self.test_transforms
+        )
+        return trainset, testset
+
+    def setup(self, stage=None):
+        if stage == "fit" or stage == "None":
+            self.dataset, _ = self.prepare_data()
+            self.train_set, self.val_set = random_split(self.dataset, [45000, 5000])
+
+        if stage == "test" or stage == "None":
+            _, self.test_set = self.prepare_data()
+
+    def train_dataloader(self):
+
+        return DataLoader(self.train_set, batch_size=64, shuffle=False)
+
+    def val_dataloader(self):
+        return DataLoader(self.val_set, batch_size=64, shuffle=False)
+
+    def test_dataloader(self):
+        return DataLoader(self.test_set, batch_size=64, shuffle=False)
+
+
+class LeNet(pl.LightningModule):
+    def __init__(self, **kwargs):
+        super(LeNet, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+        self.lr = 0.0
+        self.nesterov = False
+        self.momentum = 0.0
+        self.lr = kwargs.get("kwargs", {}).get("lr")
+        self.momentum = kwargs.get("kwargs", {}).get("momentum")
+        self.weight_decay = kwargs.get("kwargs", {}).get("weight_decay")
+        self.nesterov = kwargs.get("kwargs", {}).get("nesterov")
+
+    def forward(self, x):
+        out = F.relu(self.conv1(x))
+        out = F.max_pool2d(out, 2)
+        out = F.relu(self.conv2(out))
+        out = F.max_pool2d(out, 2)
+        out = out.view(out.size(0), -1)
+        out = F.relu(self.fc1(out))
+        out = F.relu(self.fc2(out))
+        out = self.fc3(out)
+        return F.log_softmax(out, dim=1)
+
+    def cross_entropy_loss(self, logits, labels):
+        """
+        Loss Fn to compute loss
+        """
+        return F.nll_loss(logits, labels)
+
+    def training_step(self, train_batch, batch_idx):
+        """
+        training the data as batches and returns training loss on each batch
+        """
+        x, y = train_batch
+        logits = self.forward(x)
+        loss = self.cross_entropy_loss(logits, y)
+        self.log("train_loss", loss)
+        return {"loss": loss}
+
+    def validation_step(self, val_batch, batch_idx):
+        """
+        Performs validation of data in batches
+        """
+        x, y = val_batch
+        logits = self.forward(x)
+        loss = self.cross_entropy_loss(logits, y)
+        return {"val_loss": loss}
+
+    def validation_epoch_end(self, outputs):
+        """
+        Computes average validation accuracy
+        """
+        avg_loss = torch.stack([x["val_loss"] for x in outputs]).mean()
+        self.log("val_loss", avg_loss, sync_dist=True)
+
+    def test_step(self, test_batch, batch_idx):
+        """
+        Performs test and computes test accuracy
+        """
+        x, y = test_batch
+        output = self.forward(x)
+        loss = F.cross_entropy(output, y)
+        a, y_hat = torch.max(output, dim=1)
+        test_acc = accuracy(y_hat.cpu(), y.cpu())
+        self.log("test_loss", loss)
+        self.log("test_acc", test_acc)
+        return {"test_loss": loss, "test_acc": test_acc}
+
+    def test_epoch_end(self, outputs):
+        """
+        Computes average test accuracy score
+        """
+        avg_loss = torch.stack([x["test_loss"] for x in outputs]).mean()
+        avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
+        self.log("avg_test_loss", avg_loss)
+        self.log("avg_test_acc", avg_test_acc)
+
+    def configure_optimizers(self):
+        """
+        Creates and returns Optimizer
+        """
+
+        self.optimizer = torch.optim.SGD(
+            self.parameters(),
+            lr=self.lr,
+            momentum=self.momentum,
+            nesterov=self.nesterov,
+            weight_decay=self.weight_decay,
+        )
+        return self.optimizer
+
+
+def train_evaluate(parameterization=None, dm=None, model=None, max_epochs=1):
+    trainer = pl.Trainer(max_epochs=max_epochs, callbacks=[])
+    dm.prepare_data()
+    dm.setup("fit")
+    mlflow.pytorch.autolog()
+    trainer.fit(model, dm)
+    trainer.test(datamodule=dm)
+    test_accuracy = trainer.callback_metrics.get("avg_test_acc")
+    return test_accuracy

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -1,0 +1,18 @@
+channels:
+- defaults
+- conda-forge
+- pytorch
+dependencies:
+- python=3.8.2
+- pytorch>=1.6.0
+- pip
+- pip:
+  - mlflow
+  - scikit-learn
+  - cloudpickle==1.6.0
+  - boto3
+  - pandas
+  - pytorch-lightning>=1.0.5
+  - ax-platform
+  - torchvision
+  - gorilla

--- a/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
+++ b/examples/pytorch/AxHyperOptimizationPTL/conda.yaml
@@ -5,6 +5,8 @@ channels:
 dependencies:
 - python=3.8.2
 - pytorch>=1.6.0
+- torchvision
+- cudatoolkit>=10.2
 - pip
 - pip:
   - mlflow
@@ -14,5 +16,4 @@ dependencies:
   - pandas
   - pytorch-lightning>=1.0.5
   - ax-platform
-  - torchvision
   - gorilla


### PR DESCRIPTION
Signed-off-by: ankan94 <ankan@ideas2it.com>

Adding example for Ax-Hyperparameter Optimization for PyTorch Lightning. 

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [X] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [X] `language/Python`: Python APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
