### PR TITLE
Iris Example with Model Signature

### DIFF
--- a/examples/pytorch/signature/MLproject
+++ b/examples/pytorch/signature/MLproject
@@ -1,0 +1,16 @@
+name: iris-classification
+
+conda_env: conda.yaml
+
+entry_points:
+  main:
+    parameters:
+      max_epochs: {type: int, default: 30}
+      gpus: {type: int, default: 0}
+      accelerator: {type str, default: "None"}
+
+    command: |
+          python iris_classification.py \
+            --max_epochs {max_epochs} \
+            --gpus {gpus} \
+            --accelerator {accelerator}

--- a/examples/pytorch/signature/README.md
+++ b/examples/pytorch/signature/README.md
@@ -1,0 +1,33 @@
+## Iris classification example with MLflow
+This example demonstrates training a classification model on the Iris dataset, logging the model signature into mlflow 
+and validating the model signature based on the input data. 
+
+### Running the code
+To run the example via MLflow, navigate to the `mlflow/examples/pytorch/signature` directory and run the command
+
+```
+mlflow run .
+```
+
+This will run `iris_classification.py` with the default set of parameters such as  `--max_epochs=30`. You can see the default value in the `MLproject` file.
+
+In order to run the file with custom parameters, run the command
+
+```
+mlflow run . -P epochs=X
+```
+
+where `X` is your desired value for `epochs`.
+
+If you have the required modules for the file and would like to skip the creation of a conda environment, add the argument `--no-conda`.
+
+```
+mlflow run . --no-conda
+```
+
+On the training completion, the iris classification model is saved using `mlflow.pytorch.save_model` along with the model signature.
+
+Before predicting the model output, model signature validation is performed. Only if the validation is successful, model prediction results are printed.
+
+## Running against a custom tracking server
+To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded)

--- a/examples/pytorch/signature/conda.yaml
+++ b/examples/pytorch/signature/conda.yaml
@@ -1,0 +1,14 @@
+channels:
+- defaults
+- conda-forge
+- pytorch
+dependencies:
+- python=3.8.2
+- pytorch>=1.6.0
+- torchvision
+- pip
+- pip:
+  - scikit-learn
+  - pytorch-lightning>=1.2.3
+  - git+https://github.com/chauhang/mlflow.git@iris-model-signature
+

--- a/examples/pytorch/signature/iris_classification.py
+++ b/examples/pytorch/signature/iris_classification.py
@@ -237,10 +237,14 @@ if __name__ == "__main__":
 
     model = _load_pyfunc(path="model/data", validate_signature=True)
     df = pd.read_json("sample.json")
-    print("Result with correct Input: ", model.predict(df))
+    print("Result: ", model.predict(df))
 
-    for column in df.columns:
-        df[column] = df[column].astype("str")
+    # Uncomment this block to check invalid data type enforcement
+    # for column in df.columns:
+    #     df[column] = df[column].astype("str")
+    #
+    # print("Result with invalid datatype: ", model.predict(df))
 
-    print("Result with invalid datatype: ", model.predict(df))
-
+    # Uncomment this block to check invalid column name enforcement
+    # df.columns = ["sepal_length", "sepal_width", "petal_length", "petal_width"]
+    # print("Result with invalid column name: ", model.predict(df))

--- a/examples/pytorch/signature/iris_classification.py
+++ b/examples/pytorch/signature/iris_classification.py
@@ -1,0 +1,246 @@
+# pylint: disable=W0221
+# pylint: disable=W0613
+# pylint: disable=W0223
+import argparse
+import os
+import shutil
+from argparse import ArgumentParser
+
+import mlflow
+import pytorch_lightning as pl
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from mlflow.models.signature import ModelSignature
+from mlflow.types.schema import Schema, ColSpec
+from pytorch_lightning import seed_everything
+from pytorch_lightning.metrics import Accuracy
+from sklearn.datasets import load_iris
+from torch.utils.data import DataLoader, random_split, TensorDataset
+from mlflow.pytorch import _load_pyfunc
+import pandas as pd
+
+
+class IrisClassification(pl.LightningModule):
+    def __init__(self, **kwargs):
+        super(IrisClassification, self).__init__()
+
+        self.train_acc = Accuracy()
+        self.val_acc = Accuracy()
+        self.test_acc = Accuracy()
+        self.args = kwargs
+
+        self.fc1 = nn.Linear(4, 10)
+        self.fc2 = nn.Linear(10, 10)
+        self.fc3 = nn.Linear(10, 3)
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = F.relu(self.fc3(x))
+        return x
+
+    @staticmethod
+    def add_model_specific_args(parent_parser):
+        """
+        Add model specific arguments like learning rate
+
+        :param parent_parser: Application specific parser
+
+        :return: Returns the augmented arugument parser
+        """
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument(
+            "--lr",
+            type=float,
+            default=0.01,
+            metavar="LR",
+            help="learning rate (default: 0.001)",
+        )
+        return parser
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), self.args["lr"])
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self.forward(x)
+        _, y_hat = torch.max(logits, dim=1)
+        loss = self.cross_entropy_loss(logits, y)
+        self.train_acc(y_hat, y)
+        self.log(
+            "train_acc",
+            self.train_acc.compute(),
+            on_step=False,
+            on_epoch=True,
+        )
+        self.log("train_loss", loss)
+        return {"loss": loss}
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self.forward(x)
+        _, y_hat = torch.max(logits, dim=1)
+        loss = F.cross_entropy(logits, y)
+        self.val_acc(y_hat, y)
+        self.log("val_acc", self.val_acc.compute())
+        self.log("val_loss", loss, sync_dist=True)
+
+    def test_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self.forward(x)
+        _, y_hat = torch.max(logits, dim=1)
+        self.test_acc(y_hat, y)
+        self.log("test_acc", self.test_acc.compute())
+
+
+class IrisDataModule(pl.LightningDataModule):
+    def __init__(self, **kwargs):
+        """
+        Initialization of inherited lightning data module
+        """
+        super(IrisDataModule, self).__init__()
+
+        self.train_set = None
+        self.val_set = None
+        self.test_set = None
+        self.args = kwargs
+
+    def prepare_data(self):
+        """
+        Implementation of abstract class
+        """
+
+    def setup(self, stage=None):
+        """
+        Downloads the data, parse it and split the data into train, test, validation data
+
+        :param stage: Stage - training or testing
+        """
+        iris = load_iris()
+        df = iris.data
+        target = iris["target"]
+
+        data = torch.Tensor(df).float()
+        labels = torch.Tensor(target).long()
+        RANDOM_SEED = 42
+        seed_everything(RANDOM_SEED)
+
+        data_set = TensorDataset(data, labels)
+        self.train_set, self.val_set = random_split(data_set, [130, 20])
+        self.train_set, self.test_set = random_split(self.train_set, [110, 20])
+
+    @staticmethod
+    def add_model_specific_args(parent_parser):
+        """
+        Adds model specific arguments batch size and num workers
+
+        :param parent_parser: Application specific parser
+
+        :return: Returns the augmented arugument parser
+        """
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=128,
+            metavar="N",
+            help="input batch size for training (default: 16)",
+        )
+        parser.add_argument(
+            "--num-workers",
+            type=int,
+            default=3,
+            metavar="N",
+            help="number of workers (default: 3)",
+        )
+        return parser
+
+    def create_data_loader(self, dataset):
+        """
+        Generic data loader function
+
+        :param data_set: Input data set
+
+        :return: Returns the constructed dataloader
+        """
+
+        return DataLoader(
+            dataset, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"]
+        )
+
+    def train_dataloader(self):
+        train_loader = self.create_data_loader(dataset=self.train_set)
+        return train_loader
+
+    def val_dataloader(self):
+        validation_loader = self.create_data_loader(dataset=self.val_set)
+        return validation_loader
+
+    def test_dataloader(self):
+        test_loader = self.create_data_loader(dataset=self.test_set)
+        return test_loader
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Iris Classification model")
+
+    parser.add_argument(
+        "--max_epochs", type=int, default=100, help="number of epochs to run (default: 100)"
+    )
+    parser.add_argument(
+        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
+    )
+    parser.add_argument(
+        "--save-model",
+        type=bool,
+        default=True,
+        help="For Saving the current Model",
+    )
+    parser.add_argument(
+        "--accelerator",
+        type=lambda x: None if x == "None" else x,
+        default=None,
+        help="Accelerator - (default: None)",
+    )
+
+    parser = IrisClassification.add_model_specific_args(parent_parser=parser)
+    parser = IrisDataModule.add_model_specific_args(parent_parser=parser)
+
+    args = parser.parse_args()
+    dict_args = vars(args)
+
+    dm = IrisDataModule(**dict_args)
+    dm.prepare_data()
+    dm.setup(stage="fit")
+
+    model = IrisClassification(**dict_args)
+    trainer = pl.Trainer.from_argparse_args(args)
+    trainer.fit(model, dm)
+    trainer.test()
+
+    input_schema = Schema(
+        [
+            ColSpec("double", "sepal length (cm)"),
+            ColSpec("double", "sepal width (cm)"),
+            ColSpec("double", "petal length (cm)"),
+            ColSpec("double", "petal width (cm)"),
+        ]
+    )
+    output_schema = Schema([ColSpec("long")])
+    signature = ModelSignature(inputs=input_schema, outputs=output_schema)
+    with mlflow.start_run():
+        if os.path.exists("model"):
+            shutil.rmtree("model")
+        mlflow.pytorch.save_model(trainer.get_model(), "model", signature=signature)
+
+    model = _load_pyfunc(path="model/data", validate_signature=True)
+    df = pd.read_json("sample.json")
+    print("Result with correct Input: ", model.predict(df))
+
+    for column in df.columns:
+        df[column] = df[column].astype("str")
+
+    print("Result with invalid datatype: ", model.predict(df))
+

--- a/examples/pytorch/signature/sample.json
+++ b/examples/pytorch/signature/sample.json
@@ -1,0 +1,1 @@
+{"sepal length (cm)":{"0":4.4},"sepal width (cm)":{"0":3.2},"petal length (cm)":{"0":1.3},"petal width (cm)":{"0":0.2}}


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Logging model signature and validating model signature for iris classification example. 

Reused the model signature enforcements from pyfunc.

## How is this patch tested?

Existing Unit Tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
